### PR TITLE
Update esmonduploader.py

### DIFF
--- a/libexec/probes/worker-scripts/esmonduploader/esmonduploader.py
+++ b/libexec/probes/worker-scripts/esmonduploader/esmonduploader.py
@@ -95,7 +95,7 @@ class EsmondUploader(object):
         self.dq = dq
         if self.dq != None and self.dq!='None':
             try:
-                self.mq = DQS(path=self.dq)
+                self.mq = DQS(path=self.dq, granularity=5)
             except Exception as e:
                 self.add2log("Unable to create dirq %s, exception was %s, " % (self.dq, e))
     


### PR DESCRIPTION
Following https://dirq.readthedocs.io/en/latest/queuesimple.html#dirq.QueueSimple.QueueSimple 
changed granularity option for DQS to 5 (from 60 seconds which is the default). But as this depends on the actual usage, we might need to make it configurable.
